### PR TITLE
fix: move tslib to dependencies to fix build errors in flow part

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "@vaadin/popover": "^25.0.0",
     "@vaadin/vaadin-themable-mixin": "^25.0.0",
     "@vaadin/vertical-layout": "^25.0.0",
-    "lit": "^3.0.0"
+    "lit": "^3.0.0",    
+    "tslib": "^2.4.0"
   },
   "devDependencies": {
     "@custom-elements-manifest/analyzer": "^0.6.3",
@@ -74,7 +75,6 @@
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3",
     "prettier": "^2.7.1",
-    "tslib": "^2.4.0",
     "typescript": "^5.5.2"
   },
   "bugs": {


### PR DESCRIPTION
This PR includes an update necessary for https://github.com/vaadin-component-factory/vcf-toolbar-layout-flow/issues/9